### PR TITLE
ブロックリストの初期値の Nightbot を nightbot に変更する

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -79,7 +79,7 @@ window.onload = function () {
     if (localStorage.readEmotes == null) localStorage.readEmotes = false;
     if (localStorage.voiceType == null) localStorage.voiceType = 'none';
     if (localStorage.voiceJPType == null) localStorage.voiceJPType = 'bouyomi';
-    if (localStorage.blockUser == null || JSON.parse(localStorage.blockUser)[0] != undefined) localStorage.blockUser = JSON.stringify({ 'Nightbot': false });
+    if (localStorage.blockUser == null || JSON.parse(localStorage.blockUser)[0] != undefined) localStorage.blockUser = JSON.stringify({ 'nightbot': false });
 
     voices = speechSynthesis.getVoices();
 


### PR DESCRIPTION
## 事象
- 初期値として登録されている Nightbot という文字列では Nightbot の読み上げブロックがされない。

## 原因
- `sayFunc` に渡される `userstate` の `username` は全て lowercase になっているため。

## Workaround
- 現状は Nightbot に一言でもしゃべらせた場合は nightbot が blockUserList に Read 状態で登録されるのでこちらを UnRead に設定する。
- もしくは、英語読み上げをオフにすれば基本的には読み上げされづらくはなるが、 Nightbot に日本語を設定している場合はこの回避策は十分ではない。 

## 背景
- Nightbot からのチャットは基本的には読み上げさせたくないため、ユーザビリティ向上のため、デフォルトで TwitchTalkApp 側にデフォルト値として用意されていると推測しているためここの `Nightbot` を `nightbot` に変更した。